### PR TITLE
Allow canonical_base to contain a path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const URL	= require('url');
 const _		= {
 	defaultsDeep: require('lodash.defaultsdeep'),
 	isEmpty			: require('lodash.isempty'),
@@ -9,6 +8,7 @@ const _		= {
 // -----------------------------------------------------------------------------
 
 const LIB	= require('./lib');
+const UTIL	= require('./lib/UTIL');
 
 // -----------------------------------------------------------------------------
 
@@ -361,7 +361,7 @@ PLUGIN.get_feed_url = feed =>
 
 	if ( feed.enable && feed.file_name )
 	{
-		return URL.resolve( PLUGIN.options.canonical_base, feed.file_name );
+		return UTIL.resolve_url(PLUGIN.options.canonical_base, feed.file_name);
 	}
 
 };

--- a/lib/Head.js
+++ b/lib/Head.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const URL	= require('url');
 const _		= { isEmpty: require('lodash.isempty') };
 
 // -----------------------------------------------------------------------------
@@ -11,6 +10,7 @@ const { chalk: CHALK } = require('@vuepress/shared-utils');
 
 const LIB = {
 	LOG	: require('./LOG'),
+	UTIL	: require('./UTIL'),
 };
 
 // -----------------------------------------------------------------------------
@@ -59,7 +59,7 @@ class Head
 					
 		if ( feed.head_link.enable && feed.enable && feed.file_name )
 		{
-			return URL.resolve( this.canonical_base, feed.file_name );
+			return LIB.UTIL.resolve_url( this.canonical_base, feed.file_name );
 		}
 		
 	}

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const URL	= require('url');
 const _		= { isEmpty: require('lodash.isempty') };
 
 // -----------------------------------------------------------------------------
@@ -96,7 +95,7 @@ class Page
 		
 		if ( this.canonical_base && path )
 		{
-			return URL.resolve( this.canonical_base, path );
+			return LIB.UTIL.resolve_url( this.canonical_base, path );
 		}
 	
 	}

--- a/lib/UTIL.js
+++ b/lib/UTIL.js
@@ -4,12 +4,24 @@
 
 const REMOVE_MARKDOWN	= require('remove-markdown');
 const STRIPTAGS				= require('striptags');
+const _		= {
+	trimEnd: require('lodash.trimend'),
+	trimStart: require('lodash.trimstart'),
+};
 
 // -----------------------------------------------------------------------------
 
 const UTIL = {};
 
 // -----------------------------------------------------------------------------
+
+
+/**
+ * @return {string}
+ */
+UTIL.resolve_url = (base, path) =>
+	`${_.trimEnd( base, '/' )}/${_.trimStart( path, '/' )}`;
+
 
 /**
  * @return {string}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "feed": "2.0.4",
     "lodash.defaultsdeep": "4.6.1",
     "lodash.isempty": "4.4.0",
+    "lodash.trimend": "^4.5.1",
+    "lodash.trimstart": "^4.5.1",
     "remove-markdown": "0.3.0",
     "striptags": "3.1.1"
   },


### PR DESCRIPTION
Hey,

Thanks for putting this other VuePress plugin together!

While integrating with my blog, I encountered the same issue than in https://github.com/webmasterish/vuepress-plugin-autometa/pull/6, i.e. if `canonical_base` contains a path, e.g. `https://example.com/blog`, then the path part of the URL isn't present in URLs rendered by the plugin. In particular, URLs of feed items don't contain the path prefix.

The fix is the same: use a custom `resolve_url()` helper instead of `URL.resolve()`. :-)
